### PR TITLE
Add basic differential privacy support

### DIFF
--- a/unsloth/dp_utils.py
+++ b/unsloth/dp_utils.py
@@ -1,0 +1,83 @@
+import math
+from typing import Iterable, List, Optional
+
+import numpy as np
+import torch
+
+
+class RDPAccountant:
+    """Simple Rényi Differential Privacy accountant."""
+
+    def __init__(
+        self,
+        noise_multiplier: float,
+        sample_rate: float,
+        orders: Optional[Iterable[float]] = None,
+        target_delta: float = 1e-6,
+    ) -> None:
+        self.noise_multiplier = noise_multiplier
+        self.sample_rate = sample_rate
+        self.target_delta = target_delta
+        if orders is None:
+            orders = [1 + x / 10.0 for x in range(1, 100)]
+        self.orders = np.array(list(orders), dtype=float)
+        self.rdp = np.zeros_like(self.orders)
+        self.steps = 0
+
+    def _compute_rdp(self) -> np.ndarray:
+        if self.noise_multiplier == 0:
+            return np.inf * np.ones_like(self.orders)
+        return (
+            (self.sample_rate ** 2)
+            * self.orders
+            / (2.0 * self.noise_multiplier ** 2)
+        )
+
+    def step(self) -> None:
+        self.steps += 1
+        self.rdp += self._compute_rdp()
+
+    def get_epsilon(self) -> float:
+        if self.steps == 0:
+            return 0.0
+        eps = self.rdp - math.log(self.target_delta) / (self.orders - 1)
+        return float(np.min(eps))
+
+
+class DPOptimizer(torch.optim.Optimizer):
+    """Wrap an optimizer to add DP gradient clipping and noise."""
+
+    def __init__(
+        self,
+        optimizer: torch.optim.Optimizer,
+        max_grad_norm: float,
+        noise_multiplier: float,
+        sample_rate: float,
+        accountant: Optional[RDPAccountant] = None,
+    ) -> None:
+        self.optimizer = optimizer
+        self.param_groups = self.optimizer.param_groups
+        self.defaults = self.optimizer.defaults
+        self.state = self.optimizer.state
+
+        self.max_grad_norm = max_grad_norm
+        self.noise_multiplier = noise_multiplier
+        self.sample_rate = sample_rate
+        self.accountant = accountant
+
+    def zero_grad(self, *args, **kwargs):
+        return self.optimizer.zero_grad(*args, **kwargs)
+
+    def step(self, closure=None):
+        parameters: List[torch.Tensor] = [
+            p for group in self.param_groups for p in group["params"] if p.grad is not None
+        ]
+        torch.nn.utils.clip_grad_norm_(parameters, self.max_grad_norm)
+        std = self.noise_multiplier * self.max_grad_norm
+        for p in parameters:
+            noise = torch.randn_like(p.grad) * std
+            p.grad.add_(noise)
+        result = self.optimizer.step(closure)
+        if self.accountant is not None:
+            self.accountant.step()
+        return result

--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -29,6 +29,7 @@ from unsloth_zoo.vision_utils import (
 )
 from packaging.version import Version
 import dataclasses
+from .dp_utils import DPOptimizer, RDPAccountant
 
 __all__ = [
     "UnslothTrainingArguments",
@@ -71,6 +72,22 @@ class UnslothTrainingArguments(TrainingArguments):
     embedding_learning_rate : Optional[float] = field(
         default = None,
         metadata = {"help" : "Different learning rates for embeddings and lm_head."}
+    )
+    dp_noise_multiplier : Optional[float] = field(
+        default = None,
+        metadata = {"help" : "Gaussian noise multiplier for differential privacy"}
+    )
+    dp_clip_norm : Optional[float] = field(
+        default = None,
+        metadata = {"help" : "Max gradient norm for differential privacy"}
+    )
+    dp_sample_rate : Optional[float] = field(
+        default = None,
+        metadata = {"help" : "Sample rate used for DP accountant"}
+    )
+    dp_target_delta : float = field(
+        default = 1e-6,
+        metadata = {"help" : "Target delta for RDP accountant"}
     )
 pass
 
@@ -122,19 +139,43 @@ pass
 class UnslothTrainer(SFTTrainer):
     def create_optimizer(self):
         embedding_learning_rate = getattr(self.args, "embedding_learning_rate", None)
-        if embedding_learning_rate is None: return super().create_optimizer()
 
         if self.optimizer is None:
             optimizer_cls, optimizer_kwargs = SFTTrainer.get_optimizer_cls_and_kwargs(self.args)
-            self.optimizer = _create_unsloth_optimizer(
-                self.model,
-                optimizer_cls,
-                optimizer_kwargs,
-                embedding_learning_rate,
-            )
-        pass
+            if embedding_learning_rate is None:
+                self.optimizer = optimizer_cls(self.model.parameters(), **optimizer_kwargs)
+            else:
+                self.optimizer = _create_unsloth_optimizer(
+                    self.model,
+                    optimizer_cls,
+                    optimizer_kwargs,
+                    embedding_learning_rate,
+                )
+
+            dp_noise = getattr(self.args, "dp_noise_multiplier", None)
+            dp_norm = getattr(self.args, "dp_clip_norm", None)
+            if (dp_noise is not None) and (dp_norm is not None):
+                sample_rate = getattr(self.args, "dp_sample_rate", 1.0)
+                delta = getattr(self.args, "dp_target_delta", 1e-6)
+                self.dp_accountant = RDPAccountant(
+                    noise_multiplier=dp_noise,
+                    sample_rate=sample_rate,
+                    target_delta=delta,
+                )
+                self.optimizer = DPOptimizer(
+                    self.optimizer,
+                    max_grad_norm=dp_norm,
+                    noise_multiplier=dp_noise,
+                    sample_rate=sample_rate,
+                    accountant=self.dp_accountant,
+                )
         return self.optimizer
     pass
+
+    def get_dp_epsilon(self):
+        if hasattr(self, "dp_accountant"):
+            return self.dp_accountant.get_epsilon()
+        return None
 pass
 
 # From `trl>=0.13.0`, they changed how to pass several params to the trainer


### PR DESCRIPTION
## Summary
- introduce `RDPAccountant` and `DPOptimizer` for DP gradient clipping & noise
- expose DP options in `UnslothTrainingArguments`
- wrap trainer optimizer with DP logic when arguments are provided

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6842193d98648330ab07ac7126ac3d69